### PR TITLE
feat: Migrate emojione to emoji toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ This is config with options:
 
 # Changelog
 
+## v0.0.4
+- Migrate from `emojione` to `joypixels`.Following the migrating [doc](https://github.com/joypixels/emoji-toolkit/blob/master/UPGRADE.md)
+
 ## v0.0.2
 - Merged [#1](https://github.com/Rulikkk/gatsby-remark-emoji/pull/1) that adds more conversion options
 - Improved docs about conversion options and added changelog

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const emoji = require(`emojione`);
+const joyPixels = require(`emoji-toolkit`);
 const Promise = require(`bluebird`);
 
 const defaultPluginOptions = {
@@ -10,10 +10,10 @@ module.exports = {
   mutateSource: ({ markdownNode }, pluginOptions = defaultPluginOptions) => {
     const emojiConversion =
       pluginOptions.emojiConversion || defaultPluginOptions.emojiConversion;
-    emoji.ascii = !!pluginOptions.ascii;
+    joyPixels.ascii = !!pluginOptions.ascii;
     return new Promise((resolve, reject) => {
       try {
-        markdownNode.internal.content = emoji[emojiConversion](
+        markdownNode.internal.content = joyPixels[emojiConversion](
           markdownNode.internal.content,
         );
         resolve();

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "gatsby-remark-emoji",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Add slack-style emoji to gatsby's markdown :thumbs_up:.",
   "main": "index.js",
   "author": "Rustem Mustafin <mustafin.rustem@gmail.com>",
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "emojione": "^3.1.2"
+    "emoji-toolkit": "^6.0.1"
   },
   "keywords": [
     "gatsby",
@@ -15,8 +15,8 @@
     "emoji",
     "markdown"
   ],
-  "repository" : { 
-    "type" : "git", 
-    "url" : "https://github.com/Rulikkk/gatsby-remark-emoji.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Rulikkk/gatsby-remark-emoji.git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,7 @@ bluebird@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
-emojione@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/emojione/-/emojione-3.1.2.tgz#991e30c80db4b1cf15eacb257620a7edce9c6ef4"
+emoji-toolkit@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/emoji-toolkit/-/emoji-toolkit-6.0.1.tgz#7dec51f79dd44863d86c647a805ebc41cea82a5a"
+  integrity sha512-QZZq0beHg753JxcBt89UBFqzwYNuMtXhNO+jY3viSAndewmn9biTE5glaro1RA0uWJ4hKqw4k1Mboe1M6sGkMA==


### PR DESCRIPTION
## Migrate emojione to emoji-toolkit

[EmojiOne ](https://github.com/joypixels/emojione)  has been rebranded to JoyPixels.
[The joypixels/emojione repository will no longer be updated and will eventually be deprecated](https://github.com/joypixels/emoji-toolkit/blob/master/UPGRADE.md)

## Solution

- [x] References to **emojione** in class name has changed to **joyPixels**, imported from `emoji-toolkit`
- [x] Updated version in package.json
- [x] Updated changelog in README.md

## Other fixes
Fixes some inconsistencies in emojis, like ⚠️ 
| Before | After |
|:---|:---|
|![image](https://user-images.githubusercontent.com/17777371/98970253-03e55e00-2510-11eb-89ac-2820e842261e.png)|![image](https://user-images.githubusercontent.com/17777371/98970344-1cee0f00-2510-11eb-9bee-b173f40b3018.png)|
